### PR TITLE
兼容 Violentmonkey

### DIFF
--- a/script.user.js
+++ b/script.user.js
@@ -36,7 +36,7 @@
 // @supportURL   https://github.com/Tsuk1ko/nhentai-helper/issues
 // ==/UserScript==
 
-$(function() {
+$(() => {
     'use strict';
 
     Array.prototype.remove = function(index) {
@@ -382,7 +382,11 @@ $(function() {
             });
             // pjax 后需要初始化页面以加载 lazyload 图片
             const N = unsafeWindow.N;
-            if (typeof N !== 'undefined') N.init();
+            if (typeof N !== 'undefined') {
+                N.init();
+            } else {
+                $('.gallery img').each((_, e) => $(e).attr('src', $(e).data('src')));
+            }
         }
 
         if (pageType.gallery) {

--- a/script.user.js
+++ b/script.user.js
@@ -29,27 +29,14 @@
 // @require      https://cdn.jsdelivr.net/npm/jquery-pjax@2.0.1/jquery.pjax.min.js
 // @require      https://cdn.jsdelivr.net/npm/vue@2.6.11/dist/vue.min.js
 // @require      https://cdn.jsdelivr.net/npm/noty@3.1.4/lib/noty.min.js
-// @run-at       document-end
+// @run-at       document-start
+// @inject-into  content
 // @noframes
 // @homepageURL  https://github.com/Tsuk1ko/nhentai-helper
 // @supportURL   https://github.com/Tsuk1ko/nhentai-helper/issues
 // ==/UserScript==
 
-// 防 nhentai console 屏蔽
-(function() {
-    const isNodeOrElement = typeof Node === 'object' && typeof HTMLElement === 'object' ? o => o instanceof Node || o instanceof HTMLElement : o => o && typeof o === 'object' && typeof o.nodeType === 'number' && typeof o.nodeName === 'string';
-    const c = unsafeWindow.console;
-    c._clear = c.clear;
-    c.clear = () => {};
-    c._log = c.log;
-    c.log = function() {
-        const args = Array.from(arguments).filter(value => !isNodeOrElement(value));
-        if (args.length) return c._log(...args);
-    };
-    unsafeWindow.Date = Date;
-})();
-
-(function() {
+$(function() {
     'use strict';
 
     Array.prototype.remove = function(index) {
@@ -581,4 +568,4 @@
     $(document).pjax('.pagination a, .sort a', { container: '#content', fragment: '#content', timeout: 10000 });
     $(document).on('pjax:end', () => init());
     init(true);
-})();
+});


### PR DESCRIPTION
close #3 
使用 inject-into content 隔离环境就可以避免污染. 但因为其他一些问题还是需要 `ruan-at document-start`, 并在页面加载完后 `$(fn)` 运行脚本.  
[关于 inject-into](https://violentmonkey.github.io/posts/inject-into-context/)